### PR TITLE
Fix redirection to v-1.10 docs in website (#9336)

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -69,7 +69,7 @@ fullversion = "v1.10.3"
 version = "v1.10"
 githubbranch = "v1.10.3"
 docsbranch = "release-1.10"
-url = "https://kubernetes.io"
+url = "https://v1-10.docs.kubernetes.io"
 
 [[params.versions]]
 fullversion = "v1.9.7"


### PR DESCRIPTION
- fix clicking on v-1.10 redirection to v-1.10 of the k8s docs

Signed-off-by: Shivesh <shankeyshivesh@gmail.com>

>^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
> For 1.12 Features: set Milestone to 1.12 and Base Branch to release-1.12
>^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
>
> Please delete this note before submitting the pull request.

